### PR TITLE
Update git.lua

### DIFF
--- a/config/git.lua
+++ b/config/git.lua
@@ -38,7 +38,7 @@ function git_prompt_filter()
             color = colors.dirty
         end
 
-        clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..branch..")")
+        clink.prompt.value = string.gsub(clink.prompt.value, "{git}", color.."("..branch..")\x1b[0m")
         return true
     end
 


### PR DESCRIPTION
stop colorizing of the rest of the command prompt after highlighting a git branch
